### PR TITLE
change the r version for depend.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Title: What the Package Does (one line, title case)
 Version: 0.1.0
 Authors@R: person("First", "Last", email = "first.last@example.com", role = c("aut", "cre"))
 Description: What the package does (one paragraph).
-Depends: R (>= 3.5.2)
+Depends: R (>= 3.5.1)
 License: GPL-3
 Encoding: UTF-8
 LazyData: true


### PR DESCRIPTION
```
错误：R的版本是3.5.1，程序包'add2bibtex'要求版本为>= 3.5.2的R
Error in i.p(...) : 
  (由警告转换成)installation of package ‘/var/folders/yt/307v0c_945z1rh043jsdx1lh0000gn/T//Rtmp4qCMKG/filecfefa1e6c94/add2bibtex_0.1.0.tar.gz’ had non-zero exit status
```